### PR TITLE
Interoperability with other desks

### DIFF
--- a/desk/app/mcp-server.hoon
+++ b/desk/app/mcp-server.hoon
@@ -1,6 +1,11 @@
 /-  mcp
 /+  dbug, verb, server, default-agent,
     jut=json-utils, ml=mcp
+::
+/$  tools-to-json      %mcp-tools      %json
+/$  prompts-to-json    %mcp-prompts    %json
+/$  resources-to-json  %mcp-resources  %json
+::
 |%
 ++  mcp-protocol-version  %'2025-11-25'
 ::
@@ -340,15 +345,15 @@
         ::
             [~ [%s %'tools/list']]
           :_  this
-          (send-event eyre-id (result:rpc:ml (mcp-tools-to-json:ml ~(tap in tools)) id))
+          (send-event eyre-id (result:rpc:ml (tools-to-json ~(tap in tools)) id))
         ::
             [~ [%s %'resources/list']]
           :_  this
-          (send-event eyre-id (result:rpc:ml (mcp-resources-to-json:ml ~(tap in resources)) id))
+          (send-event eyre-id (result:rpc:ml (resources-to-json ~(tap in resources)) id))
         ::
             [~ [%s %'prompts/list']]
           :_  this
-          (send-event eyre-id (result:rpc:ml (mcp-prompts-to-json:ml ~(tap in prompts)) id))
+          (send-event eyre-id (result:rpc:ml (prompts-to-json ~(tap in prompts)) id))
         ::
             [~ [%s %'resources/read']]
           =/  uri=(unit @t)

--- a/desk/app/mcp-server.hoon
+++ b/desk/app/mcp-server.hoon
@@ -340,15 +340,15 @@
         ::
             [~ [%s %'tools/list']]
           :_  this
-          (send-event eyre-id (result:rpc:ml (mcp-tools-to-json:ml tools) id))
+          (send-event eyre-id (result:rpc:ml (mcp-tools-to-json:ml ~(tap in tools)) id))
         ::
             [~ [%s %'resources/list']]
           :_  this
-          (send-event eyre-id (result:rpc:ml (mcp-resources-to-json:ml resources) id))
+          (send-event eyre-id (result:rpc:ml (mcp-resources-to-json:ml ~(tap in resources)) id))
         ::
             [~ [%s %'prompts/list']]
           :_  this
-          (send-event eyre-id (result:rpc:ml (mcp-prompts-to-json:ml prompts) id))
+          (send-event eyre-id (result:rpc:ml (mcp-prompts-to-json:ml ~(tap in prompts)) id))
         ::
             [~ [%s %'resources/read']]
           =/  uri=(unit @t)
@@ -604,20 +604,23 @@
   ^-  (unit (unit cage))
   ?+  pole  (on-peek:def `path`pole)
     ::
-    ::  .^(json %gx /=mcp-server=/tools/json)
+    ::  .^(json %gx /=mcp-server=/mcp/tools/json)
+    ::  .^((list tool:mcp) %gx /=mcp-server=/mcp/tools/noun)
     ::  read tool definitions
-    [%x %tools ~]
-      ``json+!>((mcp-tools-to-json:ml tools))
+      [%x %mcp %tools ~]
+    ``mcp-tools+!>(~(tap in tools))
     ::
-    ::  .^(json %gx /=mcp-server=/resources/json)
-    ::  read resource definitions
-    [%x %resources ~]
-      ``json+!>((mcp-resources-to-json:ml resources))
-    ::
-    ::  .^(json %gx /=mcp-server=/prompts/json)
+    ::  .^(json %gx /=mcp-server=/mcp/prompts/json)
+    ::  .^((list prompt:mcp) %gx /=mcp-server=/mcp/prompts/noun)
     ::  read prompt definitions
-    [%x %prompts ~]
-      ``json+!>((mcp-prompts-to-json:ml prompts))
+      [%x %mcp %prompts ~]
+    ``mcp-prompts+!>(~(tap in prompts))
+    ::
+    ::  .^(json %gx /=mcp-server=/mcp/resources/json)
+    ::  .^((list resource:mcp) %gx /=mcp-server=/mcp/resource/noun)
+    ::  read resource definitions
+      [%x %mcp %resources ~]
+    ``mcp-resources+!>(~(tap in resources))
   ==
 ++  on-arvo
   |=  [=(pole knot) =sign-arvo]

--- a/desk/fil/default/mcp/tools/import-mcp-prompts.hoon
+++ b/desk/fil/default/mcp/tools/import-mcp-prompts.hoon
@@ -1,0 +1,73 @@
+/-  mcp, spider
+/+  io=strandio
+^-  tool:mcp
+:*  'import-mcp-prompts'
+    'Import MCP Prompts from a desk.'
+    %-  my
+    :~  ['desk' [%string 'Desk to import MCP Prompts from.']]
+    ==
+    ~['desk']
+    ^-  thread-builder:tool:mcp
+    |=  args=(map name:parameter:tool:mcp argument:tool:mcp)
+    =/  m  (strand:spider ,vase)
+    ^-  form:m
+    =/  dek=(unit argument:tool:mcp)  (~(get by args) 'desk')
+    ?~  dek  ~|(%missing-desk !!)
+    ?>  ?=([%string *] u.dek)
+    ;<    =bowl:rand
+        bind:m
+      get-bowl:io
+    =/  prompts=(list prompt:mcp)
+      %-  zing
+      %+  murn
+        %~  tap  in
+        .^  (set [dude:gall ?])
+            %ge
+            /(scot %p our.bowl)/[p.u.dek]/(scot %da now.bowl)/$
+        ==
+      |=  [=dude:gall live=?]
+      ^-  (unit (list prompt:mcp))
+      ?.  live
+        ~
+      =/  mule-result=(each * (list tank))
+        %-  mule
+        |.
+        .^  (list prompt:mcp)
+            %gx
+            /(scot %p our.bowl)/[dude]/(scot %da now.bowl)/mcp/prompts/noun
+        ==
+      ?.  -.mule-result
+        ~
+      =/  prompt-list  ;;((list prompt:mcp) p.mule-result)
+      ?~  prompt-list
+        ~
+      `prompt-list
+    ?~  prompts
+      %-  pure:m
+      !>  ^-  json
+      %-  pairs:enjs:format
+      :~  ['type' s+'text']
+          ['text' s+(crip "No MCP Prompts found in {(trip p.u.dek)}")]
+      ==
+    ;<  ~  bind:m
+      %-  send-raw-cards:io
+      %+  turn
+        prompts
+      |=  =prompt:mcp
+      ^-  card:agent:gall
+      :*  %pass   ~
+          %agent  [our.bowl %mcp-server]
+          %poke   %add-prompt  !>(prompt)
+      ==
+    =/  prompt-names
+      %+  turn
+        prompts
+      |=  =prompt:mcp
+      name.prompt
+    %-  pure:m
+    !>  ^-  json
+    %-  pairs:enjs:format
+    :~  ['type' s+'text']
+        ['text' s+(crip "Imported MCP Prompts into %mcp-server: {<(of-wain:format prompt-names)>}")]
+    ==
+==

--- a/desk/fil/default/mcp/tools/import-mcp-resources.hoon
+++ b/desk/fil/default/mcp/tools/import-mcp-resources.hoon
@@ -1,0 +1,75 @@
+/-  mcp, spider
+/+  io=strandio
+^-  tool:mcp
+:*  'import-mcp-resources'
+    'Import MCP Resources from a desk.'
+    %-  my
+    :~  ['desk' [%string 'Desk to import MCP Resources from.']]
+    ==
+    ~['desk']
+    ^-  thread-builder:tool:mcp
+    |=  args=(map name:parameter:tool:mcp argument:tool:mcp)
+    =/  m  (strand:spider ,vase)
+    ^-  form:m
+    =/  dek=(unit argument:tool:mcp)  (~(get by args) 'desk')
+    ?~  dek  ~|(%missing-desk !!)
+    ?>  ?=([%string *] u.dek)
+    ;<    =bowl:rand
+        bind:m
+      get-bowl:io
+    =/  resources=(list resource:mcp)
+      %-  zing
+      %+  murn
+        %~  tap  in
+        .^  (set [dude:gall ?])
+            %ge
+            /(scot %p our.bowl)/[p.u.dek]/(scot %da now.bowl)/$
+        ==
+      |=  [=dude:gall live=?]
+      ^-  (unit (list resource:mcp))
+      ?.  live
+        ~
+      =/  mule-result=(each * (list tank))
+        %-  mule
+        |.
+        .^  (list resource:mcp)
+            %gx
+            /(scot %p our.bowl)/[dude]/(scot %da now.bowl)/mcp/resources/noun
+        ==
+      ?.  -.mule-result
+        ~
+      =/  resource-list  ;;((list resource:mcp) p.mule-result)
+      ?~  resource-list
+        ~
+      `resource-list
+    ?~  resources
+      %-  pure:m
+      !>  ^-  json
+      %-  pairs:enjs:format
+      :~  ['type' s+'text']
+          ['text' s+(crip "No MCP Resources found in {(trip p.u.dek)}")]
+      ==
+    ;<  ~  bind:m
+      %-  send-raw-cards:io
+      %+  turn
+        resources
+      |=  =resource:mcp
+      ~&  >>  %resource
+      ~&  >>  resource
+      ^-  card:agent:gall
+      :*  %pass   ~
+          %agent  [our.bowl %mcp-server]
+          %poke   %add-resource  !>(resource)
+      ==
+    =/  resource-names
+      %+  turn
+        resources
+      |=  =resource:mcp
+      name.resource
+    %-  pure:m
+    !>  ^-  json
+    %-  pairs:enjs:format
+    :~  ['type' s+'text']
+        ['text' s+(crip "Imported MCP Resources into %mcp-server: {<(of-wain:format resource-names)>}")]
+    ==
+==

--- a/desk/fil/default/mcp/tools/import-mcp-tools.hoon
+++ b/desk/fil/default/mcp/tools/import-mcp-tools.hoon
@@ -1,0 +1,73 @@
+/-  mcp, spider
+/+  io=strandio
+^-  tool:mcp
+:*  'import-mcp-tools'
+    'Import MCP Tools from a desk.'
+    %-  my
+    :~  ['desk' [%string 'Desk to import MCP Tools from.']]
+    ==
+    ~['desk']
+    ^-  thread-builder:tool:mcp
+    |=  args=(map name:parameter:tool:mcp argument:tool:mcp)
+    =/  m  (strand:spider ,vase)
+    ^-  form:m
+    =/  dek=(unit argument:tool:mcp)  (~(get by args) 'desk')
+    ?~  dek  ~|(%missing-desk !!)
+    ?>  ?=([%string *] u.dek)
+    ;<    =bowl:rand
+        bind:m
+      get-bowl:io
+    =/  tools=(list tool:mcp)
+      %-  zing
+      %+  murn
+        %~  tap  in
+        .^  (set [dude:gall ?])
+            %ge
+            /(scot %p our.bowl)/[p.u.dek]/(scot %da now.bowl)/$
+        ==
+      |=  [=dude:gall live=?]
+      ^-  (unit (list tool:mcp))
+      ?.  live
+        ~
+      =/  mule-result=(each * (list tank))
+        %-  mule
+        |.
+        .^  (list tool:mcp)
+            %gx
+            /(scot %p our.bowl)/[dude]/(scot %da now.bowl)/mcp/tools/noun
+        ==
+      ?.  -.mule-result
+        ~
+      =/  tool-list  ;;((list tool:mcp) p.mule-result)
+      ?~  tool-list
+        ~
+      `tool-list
+    ?~  tools
+      %-  pure:m
+      !>  ^-  json
+      %-  pairs:enjs:format
+      :~  ['type' s+'text']
+          ['text' s+(crip "No MCP Tools found in {(trip p.u.dek)}")]
+      ==
+    ;<  ~  bind:m
+      %-  send-raw-cards:io
+      %+  turn
+        tools
+      |=  =tool:mcp
+      ^-  card:agent:gall
+      :*  %pass   ~
+          %agent  [our.bowl %mcp-server]
+          %poke   %add-tool  !>(tool)
+      ==
+    =/  tool-names
+      %+  turn
+        tools
+      |=  =tool:mcp
+      name.tool
+    %-  pure:m
+    !>  ^-  json
+    %-  pairs:enjs:format
+    :~  ['type' s+'text']
+        ['text' s+(crip "Imported MCP Tools into %mcp-server: {<(of-wain:format tool-names)>}")]
+    ==
+==

--- a/desk/lib/mcp.hoon
+++ b/desk/lib/mcp.hoon
@@ -79,59 +79,6 @@
       ==
   ==
 ::
-++  mcp-tools-to-json
-  |=  tools=(list tool:mcp)
-  ^-  json
-  %-  pairs:enjs:format
-  :~  :-  'tools'
-      :-  %a
-      %+  turn
-        tools
-      |=  =tool:mcp
-      ^-  json
-      =/  properties=(map @t json)
-        %-  ~(run by parameters.tool)
-        |=  =def:parameter:tool:mcp
-        %-  pairs:enjs:format
-        :~  ['type' s+(@t type.def)]
-            ['description' s+desc.def]
-        ==
-      ::  Convert required list to JSON array
-      =/  required-array=(list json)
-        (turn required.tool |=(f=@t s+f))
-      %-  pairs:enjs:format
-      :~  ['name' [%s name.tool]]
-          ['description' [%s desc.tool]]
-          :-  'inputSchema'
-          %-  pairs:enjs:format
-          :~  ['type' [%s 'object']]
-              ['properties' [%o properties]]
-              ['required' [%a required-array]]
-          ==
-      ==
-  ==
-::
-++  mcp-resources-to-json
-  |=  resources=(list resource:mcp)
-  ^-  json
-  %-  pairs:enjs:format
-  :~  :-  'resources'
-      :-  %a
-      %+  turn
-        resources
-      |=  =resource:mcp
-      ^-  json
-      %-  pairs:enjs:format
-      %+  welp
-        :~  ['uri' s+uri.resource]
-            ['name' s+name.resource]
-            ['description' s+desc.resource]
-        ==
-      ?~  mime-type.resource  ~
-      :~  ['mimeType' s+u.mime-type.resource]
-      ==
-  ==
-::
 ++  prompt-messages-to-json
   |=  messages=(list message:prompt:mcp)
   ^-  json
@@ -148,50 +95,6 @@
           ?~  text.content.message
             ['text' s+'']
           ['text' s+u.text.content.message]
-      ==
-  ==
-::
-++  mcp-prompts-to-json
-  |=  prompts=(list prompt:mcp)
-  ^-  json
-  %-  pairs:enjs:format
-  :~  :-  'prompts'
-      :-  %a
-      %+  turn
-        prompts
-      |=  =prompt:mcp
-      ^-  json
-      %-  pairs:enjs:format
-      :~  ['name' s+name.prompt]
-          ['title' s+title.prompt]
-          ['description' s+desc.prompt]
-          :-  'arguments'
-          :-  %a
-          %+  turn
-            arguments.prompt
-          |=  arg=argument:prompt:mcp
-          ^-  json
-          %-  pairs:enjs:format
-          :~  ['name' s+name.arg]
-              ['description' s+desc.arg]
-              ['required' b+required.arg]
-          ==
-          :-  'icons'
-          :-  %a
-          %+  turn
-            icons.prompt
-          |=  =icon:prompt:mcp
-          ^-  json
-          %-  pairs:enjs:format
-          :~  ['src' s+src.icon]
-              ['mimeType' s+mime-type.icon]
-              :-  'sizes'
-              :-  %a
-              %+  turn
-                sizes.icon
-              |=  size=@t
-              [%s size]
-          ==
       ==
   ==
 --

--- a/desk/lib/mcp.hoon
+++ b/desk/lib/mcp.hoon
@@ -80,13 +80,13 @@
   ==
 ::
 ++  mcp-tools-to-json
-  |=  tool-set=(set tool:mcp)
+  |=  tools=(list tool:mcp)
   ^-  json
   %-  pairs:enjs:format
   :~  :-  'tools'
       :-  %a
       %+  turn
-        ~(tap in tool-set)
+        tools
       |=  =tool:mcp
       ^-  json
       =/  properties=(map @t json)
@@ -112,13 +112,13 @@
   ==
 ::
 ++  mcp-resources-to-json
-  |=  resource-set=(set resource:mcp)
+  |=  resources=(list resource:mcp)
   ^-  json
   %-  pairs:enjs:format
   :~  :-  'resources'
       :-  %a
       %+  turn
-        ~(tap in resource-set)
+        resources
       |=  =resource:mcp
       ^-  json
       %-  pairs:enjs:format
@@ -152,13 +152,13 @@
   ==
 ::
 ++  mcp-prompts-to-json
-  |=  prompt-set=(set prompt:mcp)
+  |=  prompts=(list prompt:mcp)
   ^-  json
   %-  pairs:enjs:format
   :~  :-  'prompts'
       :-  %a
       %+  turn
-        ~(tap in prompt-set)
+        prompts
       |=  =prompt:mcp
       ^-  json
       %-  pairs:enjs:format

--- a/desk/mar/mcp/prompts.hoon
+++ b/desk/mar/mcp/prompts.hoon
@@ -1,0 +1,48 @@
+/-  mcp
+|_  prompts=(list prompt:mcp)
+++  grad  %noun
+++  grow
+  |%
+  ++  noun  prompts
+  ++  json
+  %-  pairs:enjs:format
+  :~  :-  'prompts'
+      :-  %a
+      %+  turn
+        prompts
+      |=  =prompt:mcp
+      %-  pairs:enjs:format
+      :~  ['name' s+name.prompt]
+          ['title' s+title.prompt]
+          ['description' s+desc.prompt]
+          :-  'arguments'
+          :-  %a
+          %+  turn
+            arguments.prompt
+          |=  arg=argument:prompt:mcp
+          %-  pairs:enjs:format
+          :~  ['name' s+name.arg]
+              ['description' s+desc.arg]
+              ['required' b+required.arg]
+          ==
+          :-  'icons'
+          :-  %a
+          %+  turn
+            icons.prompt
+          |=  =icon:prompt:mcp
+          %-  pairs:enjs:format
+          :~  ['src' s+src.icon]
+              ['mimeType' s+mime-type.icon]
+              :-  'sizes'
+              :-  %a
+              %+  turn
+                sizes.icon
+              |=  size=@t
+              [%s size]
+  ==  ==  ==
+  --
+++  grab
+  |%
+  ++  noun  ,(list prompt:mcp)
+  --
+--

--- a/desk/mar/mcp/resources.hoon
+++ b/desk/mar/mcp/resources.hoon
@@ -1,0 +1,30 @@
+/-  mcp
+|_  resources=(list resource:mcp)
+++  grad  %noun
+++  grow
+  |%
+  ++  noun  resources
+  ++  json
+  %-  pairs:enjs:format
+  :~  :-  'resources'
+      :-  %a
+      %+  turn
+        resources
+      |=  =resource:mcp
+      %-  pairs:enjs:format
+      %+  welp
+        :~  ['uri' s+uri.resource]
+            ['name' s+name.resource]
+            ['description' s+desc.resource]
+        ==
+      ?~  mime-type.resource
+        ~
+      :~  ['mimeType' s+u.mime-type.resource]
+      ==
+  ==
+  --
+++  grab
+  |%
+  ++  noun  ,(list resource:mcp)
+  --
+--

--- a/desk/mar/mcp/tools.hoon
+++ b/desk/mar/mcp/tools.hoon
@@ -1,0 +1,40 @@
+/-  mcp
+|_  tools=(list tool:mcp)
+++  grad  %noun
+++  grow
+  |%
+  ++  noun  tools
+  ++  json
+  %-  pairs:enjs:format
+  :~  :-  'tools'
+      :-  %a
+      %+  turn
+        tools
+      |=  =tool:mcp
+      %-  pairs:enjs:format
+      :~  ['name' [%s name.tool]]
+          ['description' [%s desc.tool]]
+          :-  'inputSchema'
+          %-  pairs:enjs:format
+          :~  ['type' [%s 'object']]
+              :-  'properties'
+              :-  %o
+              %-  ~(run by parameters.tool)
+              |=  =def:parameter:tool:mcp
+              %-  pairs:enjs:format
+              :~  ['type' s+type.def]
+                  ['description' s+desc.def]
+              ==
+              :-  'required'
+              :-  %a
+              %+  turn
+                required.tool
+              |=  f=@t
+              s+f
+  ==  ==  ==
+  --
+++  grab
+  |%
+  ++  noun  ,(list tool:mcp)
+  --
+--


### PR DESCRIPTION
There's no best-practices way for other desks to interoperate with Urbit MCP. This PR defines and implements that.

* Adds tools `import-mcp-tools`, `import-mcp-prompts`, `import-mcp-resources` to scry MCP features out of other desks
* Reference implementation for standard scry paths:
  * `/x/mcp/tools`
  * `/x/mcp/prompts`
  * `/x/mcp/resources`
* Adds marks for other desks to import:
  * `/mar/mcp/tools.hoon`
  * `/mar/mcp/prompts.hoon`
  * `/mar/mcp/resources.hoon`