### PR TITLE
add test-build tool that captures build errors

### DIFF
--- a/desk/fil/mcp/prompts/test-build.hoon
+++ b/desk/fil/mcp/prompts/test-build.hoon
@@ -1,0 +1,40 @@
+/-  mcp
+^-  prompt:mcp
+:*  'Test build'
+    'mcp/test-build'
+    '''
+    Compile a Hoon source file and report its complete dependency build error.
+    '''
+    :~  :*  'desk'
+            'Desk containing the source file (e.g. "base" or "mcp")'
+            &
+        ==
+        :*  'path'
+            'Clay source path including its mark (e.g. "/lib/foo/hoon")'
+            &
+        ==
+    ==
+    ~
+    |=  args=(map name:argument:prompt:mcp @t)
+    ^-  (list message:prompt:mcp)
+    =/  desk-str  (~(get by args) 'desk')
+    ?~  desk-str
+      ~|(%missing-desk !!)
+    =/  path-str  (~(get by args) 'path')
+    ?~  path-str
+      ~|(%missing-path !!)
+    =/  desk-part=tape
+      ?:  =("%" -.desk-str)
+        "{(trip u.desk-str)}"
+      "%{(trip u.desk-str)}"
+    :~  :-  %user
+        :-  %text
+        %-  some
+        %-  crip
+        """
+        Use your test-build tool to compile {(trip u.path-str)} on the
+        {desk-part} desk. If it fails, report the complete compiler and
+        dependency trace returned by the tool.
+        """
+    ==
+==

--- a/desk/fil/mcp/tools/test-build.hoon
+++ b/desk/fil/mcp/tools/test-build.hoon
@@ -1,0 +1,68 @@
+/-  mcp, spider
+/+  db=builder, io=strandio
+=>
+|%
+++  print-tang
+  |=  =tang
+  ^-  @t
+  %-  of-wain:format
+  %-  zing
+  %+  turn  tang
+  |=  =tank
+  %+  turn  (wash [0 80] tank)
+  |=  =tape
+  (crip tape)
+--
+::
+^-  tool:mcp
+:*  'mcp/test-build'
+    '''
+    Compile a Hoon source file and return any build errors.
+    The build reads source through Clay at the current revision.
+    '''
+    %-  my
+    :~  :-  'desk'
+        :-  %string
+        '''
+        Desk containing the source file (e.g. "base" or "mcp").
+        '''
+        :-  'path'
+        :-  %string
+        '''
+        Clay source path including its mark (e.g. "/lib/foo/hoon").
+        '''
+    ==
+    ~['desk' 'path']
+    ^-  thread-builder:tool:mcp
+    |=  args=(map name:parameter:tool:mcp argument:tool:mcp)
+    ^-  shed:khan
+    =/  m  (strand:spider ,vase)
+    ^-  form:m
+    =/  desk-arg=(unit argument:tool:mcp)  (~(get by args) 'desk')
+    ?~  desk-arg
+      (pure:m !>([%error %missing-desk ~]))
+    ?>  ?=([%string @t] u.desk-arg)
+    =/  path-arg=(unit argument:tool:mcp)  (~(get by args) 'path')
+    ?~  path-arg
+      (pure:m !>([%error %missing-path ~]))
+    ?>  ?=([%string @t] u.path-arg)
+    ;<  =bowl:rand  bind:m  get-bowl:io
+    =/  desk=@tas  (@tas p.u.desk-arg)
+    =/  target=path  (stab p.u.path-arg)
+    =/  result=(each vase tang)
+      (~(build db [our.bowl desk now.bowl]) target)
+    ?-  -.result
+      %|
+        %-  pure:m
+        !>  ^-  response:tool:mcp
+        [%error (print-tang p.result) ~]
+      %&
+        %-  pure:m
+        !>  ^-  response:tool:mcp
+        :-  %result
+        :-  %unstructured
+        :~  :-  %text
+            (crip "Built {(spud target)} on %{(trip desk)} successfully.")
+        ==
+    ==
+==

--- a/desk/lib/builder.hoon
+++ b/desk/lib/builder.hoon
@@ -1,0 +1,246 @@
+::  Uncached, diagnostic Hoon source builder.
+::
+::  Unlike Clay %a, this returns build errors to its caller.  Every source body
+::  is guarded by a Clay %u existence scry and then fetched independently
+::  through %x.  Only compiler/composition operations are virtualized.  This
+::  first version supports /-, /+, and /= dependencies, which are the forms
+::  used by this desk; unsupported forms return an error value.
+::
+|_  [our=@p =desk now=@da]
+::  +build: build a /path/to/file/hoon and retain all compiler error tanks.
+::
+++  build
+  |=  target=path
+  ^-  (each vase tang)
+  (build-file target ~)
+::
+::  +source-path: fully qualify a Clay source path.
+::
+++  source-path
+  |=  local=path
+  ^-  path
+  (en-beam [our desk da+now] local)
+::
+::  +read-source: all actual file reads use the %x namespace.
+::
+++  read-source
+  |=  local=path
+  ^-  (unit @t)
+  ?.  (exists local)  ~
+  `[.^(@t %cx (source-path local))]
+::
+::  +exists: existence probes do not build or cache source.
+::
+++  exists
+  |=  local=path
+  ^-  ?
+  .^(? %cu (source-path local))
+::
+::  +build-file: recursively build one source file with cycle detection.
+::
+++  build-file
+  |=  [target=path active=(set path)]
+  ^-  (each vase tang)
+  ?:  (~(has in active) target)
+    [%.n ~[leaf+"dependency cycle at {(spud target)}"]]
+  =/  source=(unit @t)  (read-source target)
+  ?~  source
+    :-  %.n
+    :~  leaf+"source file does not exist: {(spud target)}"
+        leaf+"desk: {<desk>}, revision: {<now>}"
+    ==
+  =/  parsed=(each pile:clay tang)  (parse-pile target u.source)
+  ?:  ?=(%| -.parsed)
+    [%.n [leaf+"while parsing {(spud target)}" p.parsed]]
+  =/  next=(set path)  (~(put in active) target)
+  =/  subject=(each vase tang)  (run-prelude p.parsed next)
+  ?:  ?=(%| -.subject)
+    [%.n [leaf+"while building dependencies of {(spud target)}" p.subject]]
+  =/  compiled  (mule |.((slub p.subject hoon.p.parsed)))
+  ?-  -.compiled
+    %|  [%.n [leaf+"while compiling {(spud target)}" p.compiled]]
+    %&  compiled
+  ==
+::
+::  +run-prelude: construct the compilation subject in Ford's order.
+::
+++  run-prelude
+  |=  [parsed=pile:clay active=(set path)]
+  ^-  (each vase tang)
+  =/  subject=vase  !>(..zuse)
+  =/  sur-result=(each vase tang)
+    (run-tauts subject %sur sur.parsed active)
+  ?:  ?=(%| -.sur-result)  sur-result
+  =/  lib-result=(each vase tang)
+    (run-tauts p.sur-result %lib lib.parsed active)
+  ?:  ?=(%| -.lib-result)  lib-result
+  =/  raw-result=(each vase tang)
+    (run-raw p.lib-result raw.parsed active)
+  ?:  ?=(%| -.raw-result)  raw-result
+  ?:  ?|  ?=(^ raz.parsed)
+          ?=(^ maz.parsed)
+          ?=(^ caz.parsed)
+          ?=(^ bar.parsed)
+      ==
+    [%.n ~[leaf+"builder: /~, /%, /$, and /* are not implemented"]]
+  raw-result
+::
+::  +run-tauts: build /sur and /lib imports and compose their subjects.
+::
+++  run-tauts
+  |=  $:  subject=vase
+          kind=?(%lib %sur)
+          imports=(list taut:clay)
+          active=(set path)
+      ==
+  ^-  (each vase tang)
+  ?~  imports  [%.y subject]
+  =/  dependency=(unit path)  (fit-path kind pax.i.imports)
+  ?~  dependency
+    [%.n ~[leaf+"no files match /{(trip kind)}/{(trip pax.i.imports)}/hoon"]]
+  =/  built=(each vase tang)  (build-file u.dependency active)
+  ?:  ?=(%| -.built)  built
+  =/  import=vase  p.built
+  =?  p.import  ?=(^ face.i.imports)
+    [%face u.face.i.imports p.import]
+  =/  composed=vase  (slop import subject)
+  $(subject composed, imports t.imports)
+::
+::  +run-raw: build direct /= path dependencies.
+::
+++  run-raw
+  |=  $:  subject=vase
+          imports=(list [face=term =path])
+          active=(set path)
+      ==
+  ^-  (each vase tang)
+  ?~  imports  [%.y subject]
+  =/  dependency=path  (snoc path.i.imports %hoon)
+  =/  built=(each vase tang)  (build-file dependency active)
+  ?:  ?=(%| -.built)  built
+  =/  import=vase  p.built
+  =.  p.import  [%face face.i.imports p.import]
+  =/  composed=vase  (slop import subject)
+  $(subject composed, imports t.imports)
+::
+::  +fit-path: reproduce Clay's hyphen-to-path dependency search.
+::
+++  fit-path
+  |=  [prefix=@tas name=@tas]
+  ^-  (unit path)
+  =/  candidates=(list path)  (segments name)
+  |-
+  ?~  candidates  ~
+  =/  candidate=path  prefix^(snoc i.candidates %hoon)
+  ?:  (exists candidate)  `candidate
+  $(candidates t.candidates)
+::
+++  segments
+  |=  suffix=@tas
+  ^-  (list path)
+  =/  parser
+    (most hep (cook crip ;~(plug ;~(pose low nud) (star ;~(pose low nud)))))
+  =/  torn=(list @tas)  (fall (rush suffix parser) ~[suffix])
+  %-  flop
+  |-  ^-  (list (list @tas))
+  ?~  torn  ~
+  ?:  ?=([@ ~] torn)
+    ~[torn]
+  %-  zing
+  %+  turn  $(torn t.torn)
+  |=  s=(list @tas)
+  ^-  (list (list @tas))
+  ?~  s  ~
+  ~[[i.torn s] [(crip "{(trip i.torn)}-{(trip i.s)}") t.s]]
+::
+::  +parse-pile: Clay's prelude parser, copied without Ford/cache state.
+::
+++  parse-pile
+  |=  [target=path source=@t]
+  ^-  (each pile:clay tang)
+  =/  [=hair result=(unit [parsed=pile:clay =nail])]
+    %-  road  |.
+    =>  [pile-rule=pile-rule target=target source=source trip=trip]
+    ((pile-rule target) [1 1] (trip source))
+  ?^  result  [%.y parsed.u.result]
+  =/  line=@ud  p.hair
+  =/  column=@ud  q.hair
+  :-  %.n
+  :~  leaf+"syntax error at [{<line>} {<column>}] in {<target>}"
+    =/  lines=wain  (to-wain:format source)
+    ?:  (gth line (lent lines))
+      '<<end of file>>'
+    (snag (dec line) lines)
+    leaf+(runt [(dec column) '-'] "^")
+  ==
+::
+++  pile-rule
+  =>  ..lull
+  =,  clay
+  |=  pax=path
+  %-  full
+  %+  ifix
+    :_  gay
+    ::  parse optional /? and ignore
+    ::
+    ;~(plug gay (punt ;~(plug fas wut gap dem gap)))
+  |^
+  ;~  plug
+    %+  cook  (bake zing (list (list taut)))
+    %+  rune  hep
+    (most ;~(plug com gaw) taut-rule)
+  ::
+    %+  cook  (bake zing (list (list taut)))
+    %+  rune  lus
+    (most ;~(plug com gaw) taut-rule)
+  ::
+    %+  rune  tis
+    ;~(plug sym ;~(pfix gap stap))
+  ::
+    %+  rune  sig
+    ;~((glue gap) sym wyde:vast stap)
+  ::
+    %+  rune  cen
+    ;~(plug sym ;~(pfix gap ;~(pfix cen sym)))
+  ::
+    %+  rune  buc
+    ;~  (glue gap)
+      sym
+      ;~(pfix cen sym)
+      ;~(pfix cen sym)
+    ==
+  ::
+    %+  rune  tar
+    ;~  (glue gap)
+      sym
+      ;~(pfix cen sym)
+      ;~(pfix stap)
+    ==
+  ::
+    %+  stag  %tssg
+    (most gap tall:(vang & pax))
+  ==
+  ::
+  ++  pant
+    |*  fel=^rule
+    ;~(pose fel (easy ~))
+  ::
+  ++  mast
+    |*  [bus=^rule fel=^rule]
+    ;~(sfix (more bus fel) bus)
+  ::
+  ++  rune
+    |*  [bus=^rule fel=^rule]
+    %-  pant
+    %+  mast  gap
+    ;~(pfix fas bus gap fel)
+  ::
+  ++  taut-rule
+    %+  cook  |=(taut +<)
+    ;~  pose
+      (stag ~ ;~(pfix tar sym))
+      ;~(plug (stag ~ sym) ;~(pfix tis sym))
+      (cook |=(a=term [`a a]) sym)
+    ==
+  --
+--


### PR DESCRIPTION
Running unit tests works if the file actually builds but if it doesn't the agent can't see the trace cos Clay just slogs it. This means it gets stuck where it's like "it doesn't build but idk why"

To fix this I (and by "I" I mean codex) have added a test-build tool that builds the given file in the given desk but rather than asking Clay to %a build it, it uses a separate builder.hoon lib that duplicates some of Ford's build crap except it captures all errors. The builder reads the Ford prelude and builds the full dependency tree except it only supports /-, /+ and /= but most of the time that's all you're using anyway. The other ford runes could probably also be implemented, it will just complicate the builder a bit.

Hopefully this should mean agents won't get stuck on the syntax/type errors they accidentally make.