### PR TITLE
Mirror structuredContent into content for %structured tool results

### DIFF
--- a/desk/app/mcp-server.hoon
+++ b/desk/app/mcp-server.hoon
@@ -1321,7 +1321,14 @@
               ?-    response
                   [%result %structured *]
                 %-  pairs:enjs:format
-                :~  ['structuredContent' json.response]
+                :~  :-  'content'
+                    :-  %a
+                    :~  %-  pairs:enjs:format
+                        :~  ['type' s+'text']
+                            ['text' s+(en:json:html json.response)]
+                        ==
+                    ==
+                    ['structuredContent' json.response]
                     ['isError' b+.n]
                 ==
               ::


### PR DESCRIPTION
`%structured` tool results currently emit `structuredContent` without a `content` field. The MCP spec requires `content` in every `tools/call` result (`structuredContent` is supplemental, and the spec recommends servers also serialize it into a text block for compatibility). Spec-strict clients — e.g. anything built on the official `mcp` Python SDK, whose pydantic `CallToolResult` requires `content` — reject these replies entirely, so every `%structured` tool (`scry-agent`, `get-our-id`, ...) fails on those harnesses even though the data is present.

This mirrors the structured JSON into a single text block alongside the existing fields, using the same `en:json:html` idiom already used elsewhere in the file. `%error` and `%unstructured` responses are unchanged.

Verified on a fake ship: patched `%structured` replies now validate against the official SDK's `CallToolResult`, with the text block byte-identical to the re-serialized `structuredContent`; `%unstructured` and `%error` shapes are unchanged.

Before: `{"isError":false,"structuredContent":{"ship":"~bus"}}`
After: `{"isError":false,"structuredContent":{"ship":"~bus"},"content":[{"text":"{\"ship\":\"~bus\"}","type":"text"}]}`