### PR TITLE
Fix name/title order for prompts

### DIFF
--- a/desk/fil/mcp/prompts/commit-desk.hoon
+++ b/desk/fil/mcp/prompts/commit-desk.hoon
@@ -1,7 +1,7 @@
 /-  mcp
 ^-  prompt:mcp
-:*  'Commit desk'
-    'mcp/commit-desk'
+:*  'mcp/commit-desk'
+    'Commit desk'
     '''
     Commit changes to a desk.
     '''

--- a/desk/fil/mcp/prompts/dojo.hoon
+++ b/desk/fil/mcp/prompts/dojo.hoon
@@ -1,7 +1,7 @@
 /-  mcp
 ^-  prompt:mcp
-:*  'Dojo command'
-    'mcp/dojo'
+:*  'mcp/dojo'
+    'Dojo command'
     '''
     Run the given command in the Dojo
     '''

--- a/desk/fil/mcp/prompts/get-file.hoon
+++ b/desk/fil/mcp/prompts/get-file.hoon
@@ -1,7 +1,7 @@
 /-  mcp
 ^-  prompt:mcp
-:*  'Get file'
-    'mcp/get-file'
+:*  'mcp/get-file'
+    'Get file'
     '''
     Fetch a Clay file on the local ship
     '''

--- a/desk/fil/mcp/prompts/get-our-id.hoon
+++ b/desk/fil/mcp/prompts/get-our-id.hoon
@@ -1,7 +1,7 @@
 /-  mcp
 ^-  prompt:mcp
-:*  'Get Our Urbit ID'
-    'mcp/get-our-id'
+:*  'mcp/get-our-id'
+    'Get Our Urbit ID'
     'Retrieve the Urbit ID (@p) of this ship'
     ~
     ~

--- a/desk/fil/mcp/prompts/install-app.hoon
+++ b/desk/fil/mcp/prompts/install-app.hoon
@@ -1,7 +1,7 @@
 /-  mcp
 ^-  prompt:mcp
-:*  'Install app'
-    'mcp/install-app'
+:*  'mcp/install-app'
+    'Install app'
     '''
     Install a desk (local or remote).
     '''

--- a/desk/fil/mcp/prompts/install-mcp-feature.hoon
+++ b/desk/fil/mcp/prompts/install-mcp-feature.hoon
@@ -1,7 +1,7 @@
 /-  mcp
 ^-  prompt:mcp
-:*  'Install MCP feature'
-    'mcp/install-mcp-feature'
+:*  'mcp/install-mcp-feature'
+    'Install MCP feature'
     '''
     Install a single MCP feature from a beam URI by building and adding it to the mcp-server state.
     '''

--- a/desk/fil/mcp/prompts/mount-desk.hoon
+++ b/desk/fil/mcp/prompts/mount-desk.hoon
@@ -1,7 +1,7 @@
 /-  mcp
 ^-  prompt:mcp
-:*  'Mount desk'
-    'mcp/mount-desk'
+:*  'mcp/mount-desk'
+    'Mount desk'
     '''
     Mount a desk on this ship.
     '''

--- a/desk/fil/mcp/prompts/nuke-agent.hoon
+++ b/desk/fil/mcp/prompts/nuke-agent.hoon
@@ -1,7 +1,7 @@
 /-  mcp
 ^-  prompt:mcp
-:*  'Nuke agent'
-    'mcp/nuke-agent'
+:*  'mcp/nuke-agent'
+    'Nuke agent'
     '''
     Permanently wipe the state of a Gall agent.
     '''

--- a/desk/fil/mcp/prompts/revive-desk.hoon
+++ b/desk/fil/mcp/prompts/revive-desk.hoon
@@ -1,7 +1,7 @@
 /-  mcp
 ^-  prompt:mcp
-:*  'Revive desk'
-    'mcp/revive-desk'
+:*  'mcp/revive-desk'
+    'Revive desk'
     '''
     Boot the agents on a nuked / suspended desk.
     '''

--- a/desk/fil/mcp/prompts/run-tests.hoon
+++ b/desk/fil/mcp/prompts/run-tests.hoon
@@ -1,7 +1,7 @@
 /-  mcp
 ^-  prompt:mcp
-:*  'Run tests'
-    'mcp/run-tests'
+:*  'mcp/run-tests'
+    'Run tests'
     '''
     Run unit tests and/or integration tests, given a desk and a path prefix.
     '''

--- a/desk/fil/mcp/prompts/test-build.hoon
+++ b/desk/fil/mcp/prompts/test-build.hoon
@@ -1,7 +1,7 @@
 /-  mcp
 ^-  prompt:mcp
-:*  'Test build'
-    'mcp/test-build'
+:*  'mcp/test-build'
+    'Test build'
     '''
     Compile a Hoon source file and report its complete dependency build error.
     '''


### PR DESCRIPTION
Names and titles were mixed up in the `/fil/mcp/prompt` files, which broke user-initiated prompt snippets in Claude Code.