### PR TITLE
Re-run install-features from on-load so desk updates register new features

### DIFF
--- a/desk/app/mcp-server.hoon
+++ b/desk/app/mcp-server.hoon
@@ -532,7 +532,20 @@
             %add-resource  'notifications/resources/list_changed'
             %add-template  'notifications/resources/list_changed'
           ==
-        :-  (broadcast-list-changed bowl sse-sessions notif)
+        ::  An add that leaves the feature set as it was (for instance
+        ::  the install-features thread re-importing an unchanged file
+        ::  on load) is not a list change; skip the broadcast for it.
+        ::
+        =/  changed=?
+          ?-  mark
+            %add-tool      !(~(has in tools) !<(tool:mcp vase))
+            %add-prompt    !(~(has in prompts) !<(prompt:mcp vase))
+            %add-resource  !(~(has in resources) !<(resource:mcp vase))
+            %add-template  !(~(has in templates) !<(template:resource:mcp vase))
+          ==
+        :-  ?.  changed
+              ~
+            (broadcast-list-changed bowl sse-sessions notif)
         ?-  mark
           %add-tool
             =/  new=tool:mcp  !<(tool:mcp vase)

--- a/desk/app/mcp-server.hoon
+++ b/desk/app/mcp-server.hoon
@@ -237,6 +237,34 @@
     (trip (en:json:html json))
 ::
 +$  card  card:agent:gall
+::
+::  +install-features-card: fire /ted/install-features over every file
+::  under /fil/mcp, registering tools, prompts, resources, and templates.
+::  Imports replace entries by name, so re-firing this card is idempotent;
+::  entries added at runtime under other names are untouched.
+::
+++  install-features-card
+  |=  [our=ship =desk now=@da]
+  ^-  card
+  :*  %pass  ~
+      %arvo  %k
+      %fard  desk
+      %install-features
+      :-  %noun
+      !>  ^-  (list beam)
+      %+  turn
+        .^  (list path)
+            %ct
+            /(scot %p our)/[desk]/(scot %da now)/fil/mcp
+        ==
+      |=  pax=path
+      ^-  beam
+      %-  need
+      %-  de-beam
+      %+  welp
+        /(scot %p our)/[desk]/(scot %da now)
+      pax
+  ==
 +$  versioned-state
   $%  state-0
   ==
@@ -280,10 +308,16 @@
         %arvo  %e  %connect
         [[~ ~['.well-known']] dap.bowl]
     ==
+  ::  Re-run install-features on every load so tool, prompt, resource,
+  ::  and template files brought in by a desk update register without a
+  ::  manual %fard. Re-firing is idempotent: imports replace by name.
+  ::
+  =/  reimport-card=card
+    (install-features-card our.bowl q.byk.bowl now.bowl)
   ?-    -.old
       %0
     :_  this(state [%0 +.old])
-    :~  well-known-card  oauth-card  ==
+    :~  well-known-card  oauth-card  reimport-card  ==
   ==
 ::
 ++  on-init
@@ -312,25 +346,8 @@
           %arvo  %e  %connect
           [[~ ~['oauth']] dap.bowl]
       ==
-      :*  %pass  ~
-          %arvo  %k
-          %fard  q.byk.bowl
-          %install-features
-          :-  %noun
-          !>  ^-  (list beam)
-          %+  turn
-            .^  (list path)
-                %ct
-                /(scot %p our.bowl)/[q.byk.bowl]/(scot %da now.bowl)/fil/mcp
-            ==
-          |=  pax=path
-          ^-  beam
-          %-  need
-          %-  de-beam
-          %+  welp
-            /(scot %p our.bowl)/[q.byk.bowl]/(scot %da now.bowl)
-          pax
-  ==  ==
+      (install-features-card our.bowl q.byk.bowl now.bowl)
+  ==
 ::
 ++  on-poke
   |=  [=mark =vase]

--- a/desk/app/mcp-server.hoon
+++ b/desk/app/mcp-server.hoon
@@ -238,32 +238,91 @@
 ::
 +$  card  card:agent:gall
 ::
+::  +feature-files: every file under /fil/mcp at the current revision
+::
+++  feature-files
+  |=  =bowl:gall
+  ^-  (list path)
+  .^  (list path)
+      %ct
+      /(scot %p our.bowl)/[q.byk.bowl]/(scot %da now.bowl)/fil/mcp
+  ==
+::
 ::  +install-features-card: fire /ted/install-features over every file
 ::  under /fil/mcp, registering tools, prompts, resources, and templates.
 ::  Imports replace entries by name, so re-firing this card is idempotent;
 ::  entries added at runtime under other names are untouched.
 ::
 ++  install-features-card
-  |=  [our=ship =desk now=@da]
+  |=  =bowl:gall
   ^-  card
   :*  %pass  ~
       %arvo  %k
-      %fard  desk
+      %fard  q.byk.bowl
       %install-features
       :-  %noun
       !>  ^-  (list beam)
       %+  turn
-        .^  (list path)
-            %ct
-            /(scot %p our)/[desk]/(scot %da now)/fil/mcp
-        ==
+        (feature-files bowl)
       |=  pax=path
       ^-  beam
       %-  need
       %-  de-beam
       %+  welp
-        /(scot %p our)/[desk]/(scot %da now)
+        /(scot %p our.bowl)/[q.byk.bowl]/(scot %da now.bowl)
       pax
+  ==
+::
+::  +load-changed-cards: per-class list_changed notifications for the
+::  features a desk update will register.  A feature's name lives inside
+::  its file, not in the filename, and resolving it would mean building
+::  every file during +on-load, so this compares a coarse proxy: the
+::  number of files under /fil/mcp/<class> against the number of
+::  features the class held before the load.  A no-op reload leaves the
+::  counts equal (no notification); a new file makes them differ (one
+::  notification for its class).  Features added at runtime skew the
+::  count, at worst causing a spurious or missed notification here;
+::  clients treat list_changed as a hint to re-fetch, and the %add-*
+::  pokes the install-features thread sends still notify per change.
+::
+++  load-changed-cards
+  |=  [=bowl:gall old=state-0]
+  ^-  (list card)
+  =/  files  (feature-files bowl)
+  =/  count-under
+    |=  prefix=path
+    ^-  @ud
+    %-  lent
+    %+  skim  files
+    |=  pax=path
+    =(prefix (scag (lent prefix) pax))
+  %-  zing
+  ^-  (list (list card))
+  :~  ?:  =((count-under /fil/mcp/tools) ~(wyt in tools.old))
+        ~
+      %:  broadcast-list-changed
+          bowl
+          sse-sessions.old
+          'notifications/tools/list_changed'
+      ==
+    ::
+      ?:  =((count-under /fil/mcp/prompts) ~(wyt in prompts.old))
+        ~
+      %:  broadcast-list-changed
+          bowl
+          sse-sessions.old
+          'notifications/prompts/list_changed'
+      ==
+    ::
+      ?:  ?&  =((count-under /fil/mcp/resources) ~(wyt in resources.old))
+              =((count-under /fil/mcp/templates) ~(wyt in templates.old))
+          ==
+        ~
+      %:  broadcast-list-changed
+          bowl
+          sse-sessions.old
+          'notifications/resources/list_changed'
+      ==
   ==
 +$  versioned-state
   $%  state-0
@@ -308,16 +367,21 @@
         %arvo  %e  %connect
         [[~ ~['.well-known']] dap.bowl]
     ==
-  ::  Re-run install-features on every load so tool, prompt, resource,
-  ::  and template files brought in by a desk update register without a
-  ::  manual %fard. Re-firing is idempotent: imports replace by name.
-  ::
-  =/  reimport-card=card
-    (install-features-card our.bowl q.byk.bowl now.bowl)
   ?-    -.old
       %0
     :_  this(state [%0 +.old])
-    :~  well-known-card  oauth-card  reimport-card  ==
+    ::  Re-run install-features on every load so tool, prompt, resource,
+    ::  and template files brought in by a desk update register without a
+    ::  manual %fard (re-firing is idempotent: imports replace by name),
+    ::  and tell connected clients which feature lists will change.
+    ::
+    %+  weld
+      ^-  (list card)
+      :~  oauth-card
+          well-known-card
+          (install-features-card bowl)
+      ==
+    (load-changed-cards bowl old)
   ==
 ::
 ++  on-init
@@ -346,7 +410,7 @@
           %arvo  %e  %connect
           [[~ ~['oauth']] dap.bowl]
       ==
-      (install-features-card our.bowl q.byk.bowl now.bowl)
+      (install-features-card bowl)
   ==
 ::
 ++  on-poke


### PR DESCRIPTION
### Problem

Tools (and prompts/resources/templates) added by a desk update never register with the running agent. `++on-init` fires `/ted/install-features` over everything under /fil/mcp, but only at first install; `++on-load` re-binds the Eyre endpoints and nothing else. So when a desk update brings new files under /fil/mcp, they sit as dead files in Clay: present in `%cy` scries, absent from the agent's `tools` set.

Observed on a live ship after updating to a desk that added `test-build`, `run-thread` and `build-pill`: the `/mcp/tools/json` scry returned 23 tools, none of the new three. The only recovery was a manual

    |pass [%k %fard %mcp %install-features %noun !>(`(list beam)`~[...])]

Reproduced on a fresh fake ship (urbit 4.6): install the desk with one tool file omitted (26 tools registered), add the file, `|commit` — the file lands in Clay (`.^(? %cu ...)` -> `%.y`) but the tool list stays at 26. The manual `%fard` brings it to 27.

### Fix

Factor the install-features card out of `on-init` into `+install-features-card` and fire it from `on-load` as well. Re-firing is idempotent: the import pokes replace entries by name, so file-defined features are refreshed to their on-disk definitions and runtime-added features under other names are untouched.

### Verification (fresh fake ship, urbit 4.6)

- Installed the desk at stock 323b331 minus `fil/mcp/tools/test-build.hoon`: `/mcp/tools/json` scry -> 26 tools, `mcp/test-build` absent.
- Upgraded the mounted desk with this branch's `app/mcp-server.hoon` plus `test-build.hoon` in a single `|commit`. Dojo showed `gall: reloading %mcp-server`; with NO manual `%fard`, the scry then returned 27 tools, set-diff vs before exactly `['mcp/test-build']`.
- Re-import is idempotent in practice: a later on-load (suspend/revive) re-imported all existing tools with no duplicate names, and both re-imported and newly swept-up tools execute correctly when called (their thread-builder gates are live, not bunts).

### Known limitation

Gall only reloads an agent (and hence runs `on-load`) when the agent's build changes. A desk commit that only touches /fil does not reload the agent, so this fix does not fire for pure-/fil updates — those files register at the next agent-reloading event (verified: a pure-/fil commit of a new tool file registered nothing; the next suspend/revive swept it up). Covering pure-/fil updates would need a Clay `%warp` subscription on /fil, deliberately not built here to keep the change minimal.

### Related (not fixed here)

On the same live ship, `mcp/import-mcp-tools` — the tool that would otherwise be the recovery path — fails with `McpError: / gx <ship> mcp-server <date> mcp tools noun`. Live probes narrowed it: the raw scry `.^((list *) %gx /=mcp-server=/mcp/tools/noun)` resolves fine (27 entries) while the typed `(list tool:mcp)` scry inside the thread still crashes, so the failure is in molding the live state (registered under an older desk revision's type definitions) through the current `tool:mcp`, not in path resolution or the mark tube. Since the import's pre/post scries only need names, switching them to the `/json` endpoint (or a name-only mold) would make the tool robust across desk revisions. Happy to file that as a separate issue/PR if useful.

### Test suite

The repo has no /tests directory; `-test /=mcp=/tests ~` fails with `%no-tests-at-path`. Nothing to run.
