### PR TITLE
Convert insert-file content through the mark's mime arm

### DIFF
--- a/desk/fil/mcp/tools/insert-file.hoon
+++ b/desk/fil/mcp/tools/insert-file.hoon
@@ -4,6 +4,10 @@
 :*  'mcp/insert-file'
     '''
     Insert a file into the Clay filesystem.
+    Content is supplied as text and converted to the target mark through that
+    mark's +grab:mime arm, exactly as if the file had been written into a
+    mounted desk and committed. Structured marks (%bill, %kelvin, %docket-0,
+    %json) therefore work as well as source marks (%hoon, %txt, %md).
     Will fail if the target desk doesn't have the given mark in /desk/mar/...
     '''
     %-  my
@@ -43,16 +47,41 @@
       (pure:m !>([%error %missing-context ~]))
     ?>  ?=([%string @t] u.cot)
     ;<  =bowl:rand  bind:m  get-bowl:io
+    =/  des=desk  (@tas p.u.dek)
+    ::  own: a beam we know exists, for enumerating desks
+    ::  bek: the target desk's beam, for mark lookup and conversion
+    ::
+    =/  own=path  /(scot %p our.bowl)/[q.byk.bowl]/(scot %da now.bowl)
+    =/  bek=path  /(scot %p our.bowl)/[des]/(scot %da now.bowl)
+    ?.  ?=([@ @ *] pax)
+      %-  pure:m
+      !>  ^-  response:tool:mcp
+      :+  %error
+        'filepath needs at least two components, ending in the mark (e.g. /desk/bill)'
+      ~
+    ?.  (~(has in .^((set desk) %cd own)) des)
+      %-  pure:m
+      !>  ^-  response:tool:mcp
+      [%error (crip "no such desk: %{(trip des)}") ~]
+    =/  mar=mark  (rear pax)
+    ?.  .^(? %cu (weld bek /mar/[mar]/hoon))
+      %-  pure:m
+      !>  ^-  response:tool:mcp
+      [%error (crip "desk %{(trip des)} has no /mar/{(trip mar)}/hoon") ~]
+    ::  convert text -> %mime -> target mark, the way a commit would
+    ::
+    =/  =tube:clay  .^(tube:clay %cc (weld bek /mime/[mar]))
+    =/  vax=vase  (tube !>(`mime`[/text/plain (as-octs:mimes:html p.u.cot)]))
     ;<  ~  bind:m
       %:  send-raw-card:io
           %pass   /insert-file
           %arvo   %c  %info
-          [(@tas p.u.dek) %& [pax %ins (rear pax) !>(p.u.cot)]~]
+          [des %& [pax %ins mar vax]~]
       ==
     %-  pure:m
     !>  ^-  response:tool:mcp
     :-  %result
     :-  %unstructured
-    :~  [%text (crip "Inserted file {<pax>} into desk {<dek>}")]
+    :~  [%text (crip "Inserted {(spud pax)} into desk %{(trip des)}")]
     ==
 ==


### PR DESCRIPTION
Upstreaming a patch from tlon's [fork](https://github.com/tloncorp/mcp/pull/20):

## Problem

`insert-file` tags the raw `content` string with the mark taken off the end of the filepath and hands Clay the cage directly:

```hoon
[(@tas p.u.dek) %& [pax %ins (rear pax) !>(p.u.cot)]~]
```

Clay mold-checks that noun against the mark's sample, so the tool only ever worked for marks whose sample is `@t` — `%hoon`, `%md`, `%css`. Anything structured failed:

| mark | sample |
|---|---|
| `%bill` | `(list dude:gall)` |
| `%kelvin` | `waft:clay` |
| `%txt` | `wain` |
| `%docket-0` | `docket` |
| `%json` | `json` |

Writing a `desk.bill` or a `sys.kelvin` from MCP wasn't possible at all — you had to mount the desk and `|commit`.

Worse, the failure was an uncaught Clay crash. Over HTTP it surfaces as `Error POSTing to endpoint: crud!`; in the ship's log it's `%validate-page-fail /desk/bill %from %bill` under a wall of `/sys/vane/clay/hoon` frames. Nothing points at the actual cause, and the mark's own `+grab:mime` never runs, so it looks like the mark file is broken when it isn't.

## Fix

Convert text → `%mime` → target mark through a `%cc` tube, which is precisely what a commit off a mounted desk does. The same marks that work on disk now work here.

- `%hoon` is unaffected — its `+grab:mime` is `(@t q.q)`.
- `%txt` now stores a proper `wain` instead of a cord (it used to crash).
- `%mime` does not need to be in the target desk; this works in a bare `|new-desk` desk.

Three crash paths become real error responses: unknown desk, mark missing from the target desk, and a filepath too short to carry a mark. Also fixes the success message, which printed the raw unit (`into desk [~ u=[%string p='billtest']]`) and the raw path.

## Testing

End to end on a dev ship against a scratch `|new-desk` desk with `mar/bill.hoon` added:

- `/desk/bill` ← `:~  %charlie\n    %delta\n==` → reads back as `charlie` / `delta`
- `/sys/kelvin` ← `[%zuse 408]` → round-trips to `[%zuse 408]`
- `/notes/txt` ← three lines → stored as a 3-element `wain`
- `.hoon` still works (this tool's own source was updated through itself)
- unknown desk → `no such desk: %nodesk`
- missing mark → `desk %billtest has no /mar/docket-0/hoon`
- `/bill` → `filepath needs at least two components, ending in the mark (e.g. /desk/bill)`

## Note for a follow-up

`import-mcp-tools` wraps its per-agent scry in `mule`, but `.^` can't run under `mule` (virtualized nock gets no scry handler), so a desk with an agent that doesn't serve `/mcp/tools` — `%oauth` on the `%mcp` desk — fails the whole thread instead of being skipped. Not touched here.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01DmTjck1kbbC41xFxAGcJeJ